### PR TITLE
feat(rule): add no-invalid-control-character

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@
     - 文の敬体(ですます調)、常体(である調)の混合をチェック
 - https://github.com/azu/textlint-rule-no-nfd
     - ホ゜ケット エンシ゛ン のような、Mac OS XでPDFやFinderからのコピペで発生する濁点のチェック
-
+- https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+    - 制御文字の検出
 
 ## Usage
 
@@ -91,7 +92,10 @@ Options
              // https://github.com/azu/textlint-rule-no-nfd
              // ホ゜ケット エンシ゛ン
              // のような、Mac OS XでPDFやFinderからのコピペで発生する濁点のチェック
-             "no-nfd": true
+             "no-nfd": true,
+             // https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+             // 制御文字の検出
+             "no-invalid-control-character": true
         }
     }
 }

--- a/lib/textlint-rule-preset-japanese.js
+++ b/lib/textlint-rule-preset-japanese.js
@@ -10,7 +10,8 @@ module.exports = {
         "sentence-length": require("textlint-rule-sentence-length"),
         "no-dropping-the-ra": require("textlint-rule-no-dropping-the-ra"),
         "no-mix-dearu-desumasu": require("textlint-rule-no-mix-dearu-desumasu"),
-        "no-nfd": require("textlint-rule-no-nfd")
+        "no-nfd": require("textlint-rule-no-nfd"),
+        "no-invalid-control-character": require("textlint-rule-no-invalid-control-character")
     },
     "rulesConfig": {
         // https://github.com/textlint-ja/textlint-rule-max-ten
@@ -48,6 +49,9 @@ module.exports = {
         // https://github.com/azu/textlint-rule-no-nfd
         // ホ゜ケット エンシ゛ン
         // のような、Mac OS XでPDFやFinderからのコピペで発生する濁点のチェック
-        "no-nfd": true
+        "no-nfd": true,
+        // https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
+        // 制御文字の検出
+        "no-invalid-control-character": true
     }
 };

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "textlintrule"
   ],
   "dependencies": {
+    "@textlint-rule/textlint-rule-no-invalid-control-character": "^1.0.1",
     "textlint-rule-max-ten": "^2.0.2",
     "textlint-rule-no-double-negative-ja": "^1.0.3",
     "textlint-rule-no-doubled-conjunction": "^1.0.2",


### PR DESCRIPTION
It's useful. Can be included by preset-japanese?