### PR TITLE
Fixed invalid link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # textlint-rule-preset-japanese [![Build Status](https://travis-ci.org/textlint-ja/textlint-rule-preset-japanese.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-preset-japanese)
 
-[textlint rule preset](https://github.com/textlint/textlint/blob/master/docs/create-preset.md "preset") for Japanese.
+[textlint rule preset](https://github.com/textlint/textlint/blob/master/docs/rule-preset.md "preset") for Japanese.
 
 日本語向けのtextlint ruleのpresetです。
 


### PR DESCRIPTION
Following https://github.com/textlint/textlint/commit/e07931beeaf1520cdbd404f73afe9f287dd2325a#diff-b42e5f024b70848332eed52e34b1a085