### PR TITLE
no-zero-width-spaces ルールを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@
     - ホ゜ケット エンシ゛ン のような、Mac OS XでPDFやFinderからのコピペで発生する濁点のチェック
 - https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
     - 制御文字の検出
+- https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
+    - ゼロ幅スペースの検出
 
 ## Usage
 
@@ -99,7 +101,10 @@ Options
              "no-nfd": true,
              // https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
              // 制御文字の検出
-             "no-invalid-control-character": true
+             "no-invalid-control-character": true,
+             // https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
+             // ゼロ幅スペースの検出
+             "no-zero-width-spaces": true
         }
     }
 }

--- a/lib/textlint-rule-preset-japanese.js
+++ b/lib/textlint-rule-preset-japanese.js
@@ -11,7 +11,8 @@ module.exports = {
         "no-dropping-the-ra": moduleInterop(require("textlint-rule-no-dropping-the-ra")),
         "no-mix-dearu-desumasu": moduleInterop(require("textlint-rule-no-mix-dearu-desumasu")),
         "no-nfd": moduleInterop(require("textlint-rule-no-nfd")),
-        "no-invalid-control-character": moduleInterop(require("@textlint-rule/textlint-rule-no-invalid-control-character"))
+        "no-invalid-control-character": moduleInterop(require("@textlint-rule/textlint-rule-no-invalid-control-character")),
+        "no-zero-width-spaces": moduleInterop(require("textlint-rule-no-zero-width-spaces"))
     },
     "rulesConfig": {
         // https://github.com/textlint-ja/textlint-rule-max-ten
@@ -52,6 +53,9 @@ module.exports = {
         "no-nfd": true,
         // https://github.com/textlint-rule/textlint-rule-no-invalid-control-character
         // 制御文字の検出
-        "no-invalid-control-character": true
+        "no-invalid-control-character": true,
+        // https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
+        // ゼロ幅スペースの検出
+        "no-zero-width-spaces": true
     }
 };

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "textlint-rule-no-dropping-the-ra": "^3.0.0",
     "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
     "textlint-rule-no-nfd": "^1.0.1",
+    "textlint-rule-no-zero-width-spaces": "^1.0.1",
     "textlint-rule-prh": "^5.2.0",
     "textlint-rule-sentence-length": "^2.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2566,6 +2566,11 @@ textlint-rule-no-nfd@^1.0.1:
     textlint-rule-helper "^2.1.1"
     unorm "^1.4.1"
 
+textlint-rule-no-zero-width-spaces@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/textlint-rule-no-zero-width-spaces/-/textlint-rule-no-zero-width-spaces-1.0.1.tgz#15a6abda05f08e483d5bb33a7034d904259d77a3"
+  integrity sha512-AkxpzBILGB4YsXddzHx2xqpXmqMv5Yd+PQm4anUV+ADSJuwLP1Jd6yHf/LOtu9j3ps8K3XM9vQrXRK73z0bU3A==
+
 textlint-rule-prh@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-prh/-/textlint-rule-prh-5.3.0.tgz#c3a002e3e1b59751eb6b93dff81810caeb764a9f"


### PR DESCRIPTION
[textlint-rule-no-zero-width-spaces](https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
) を追加しました。

・目視で見つけることができないため[ゼロ幅スペース](https://ja.wikipedia.org/wiki/%E3%82%BC%E3%83%AD%E5%B9%85%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9
)を、textlint で見つけることができるようになります。
・デスクワークをしていると、受け取ったデータのなかにゼロ幅スペースが混入していることがあるらしい……です。
・制御文字の検出ルール（textlint-rule-no-invalid-control-character）と同様に、ゼロ幅スペースの検出も textlint-rule-preset-japanese に含めることができそうです。

## 動作確認

example/README.md にゼロ幅スペースを入れてみたときに、`yarn test` が失敗すること。

```bash
$ yarn test
yarn run v1.22.10
$ cd example && yarn install && npm test
[1/4] Resolving packages...
success Already up-to-date.

> textlint-rule-preset-japanese@1.0.0-local test
> textlint README.md


/home/hata6502/textlint-rule-preset-japanese/example/README.md
  7:6  ✓ error  Zero width space is disallowed  japanese/no-zero-width-spaces

✖ 1 problem (1 error, 0 warnings)
✓ 1 fixable problem.
Try to run: $ textlint --fix [file]

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

example/README.md をもとに戻したときに、`yarn test` が成功すること。

```bash
$ yarn test
yarn run v1.22.10
$ cd example && yarn install && npm test
[1/4] Resolving packages...
success Already up-to-date.

> textlint-rule-preset-japanese@1.0.0-local test
> textlint README.md

Done in 1.69s.

```

↓ゼロ幅スペースが入っている文章
> Lorem​Ipsum
