### PR TITLE
no-kangxi-radicals ルールを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@
     - 制御文字の検出
 - https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
     - ゼロ幅スペースの検出
+- https://github.com/xl1/textlint-rule-no-kangxi-radicals
+    - 康煕部首の検出
 
 ## Usage
 
@@ -104,7 +106,10 @@ Options
              "no-invalid-control-character": true,
              // https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
              // ゼロ幅スペースの検出
-             "no-zero-width-spaces": true
+             "no-zero-width-spaces": true,
+             // https://github.com/xl1/textlint-rule-no-kangxi-radicals
+             // 康煕部首の検出
+             "no-kangxi-radicals": true
         }
     }
 }

--- a/lib/textlint-rule-preset-japanese.js
+++ b/lib/textlint-rule-preset-japanese.js
@@ -12,7 +12,8 @@ module.exports = {
         "no-mix-dearu-desumasu": moduleInterop(require("textlint-rule-no-mix-dearu-desumasu")),
         "no-nfd": moduleInterop(require("textlint-rule-no-nfd")),
         "no-invalid-control-character": moduleInterop(require("@textlint-rule/textlint-rule-no-invalid-control-character")),
-        "no-zero-width-spaces": moduleInterop(require("textlint-rule-no-zero-width-spaces"))
+        "no-zero-width-spaces": moduleInterop(require("textlint-rule-no-zero-width-spaces")),
+        "no-kangxi-radicals": moduleInterop(require("textlint-rule-no-kangxi-radicals"))
     },
     "rulesConfig": {
         // https://github.com/textlint-ja/textlint-rule-max-ten
@@ -56,6 +57,9 @@ module.exports = {
         "no-invalid-control-character": true,
         // https://github.com/textlint-rule/textlint-rule-no-zero-width-spaces
         // ゼロ幅スペースの検出
-        "no-zero-width-spaces": true
+        "no-zero-width-spaces": true,
+        // https://github.com/xl1/textlint-rule-no-kangxi-radicals
+        // 康煕部首の検出
+        "no-kangxi-radicals": true
     }
 };

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "textlint-rule-no-doubled-conjunctive-particle-ga": "^2.0.1",
     "textlint-rule-no-doubled-joshi": "^4.0.0",
     "textlint-rule-no-dropping-the-ra": "^3.0.0",
+    "textlint-rule-no-kangxi-radicals": "^0.1.0",
     "textlint-rule-no-mix-dearu-desumasu": "^5.0.0",
     "textlint-rule-no-nfd": "^1.0.1",
     "textlint-rule-no-zero-width-spaces": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2548,6 +2548,13 @@ textlint-rule-no-dropping-the-ra@^3.0.0:
     kuromojin "^3.0.0"
     textlint-rule-helper "^2.1.1"
 
+textlint-rule-no-kangxi-radicals@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/textlint-rule-no-kangxi-radicals/-/textlint-rule-no-kangxi-radicals-0.1.0.tgz#a765c5711570192cfc85caaf68e7a5814346c6cb"
+  integrity sha512-O5+VdjE70abZbLIsSSxbenXJTZvUi5HYY3CkXjcIYTbnytjqH0Wrz/P7MHp15YTK8EChHYKiqKNkcsbdOkmIEg==
+  dependencies:
+    match-index "^1.0.3"
+
 textlint-rule-no-mix-dearu-desumasu@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/textlint-rule-no-mix-dearu-desumasu/-/textlint-rule-no-mix-dearu-desumasu-5.0.0.tgz#c17ebc015cafc75ca38d10766f18c7593ee9c239"


### PR DESCRIPTION
[textlint-rule-no-kangxi-radicals](https://github.com/xl1/textlint-rule-no-kangxi-radicals) を追加しました。

PDF をコピーペーストしたときによく含まれる、康煕部首を見つけることができるルールです。
詳しくは、ルール作者が書かれた「[PDF に謎の漢字が含まれるとき](https://gist.github.com/xl1/940d653451fd96a06618a6df08d5df84)」を参照してください。

ルール作者：@xl1

## 動作確認

example/README.md に康煕部首を入れてみたときに、`yarn test` が失敗すること。

```bash
$ yarn test
yarn run v1.22.10
$ textlint README.md

/home/hata6502/textlint-rule-preset-japanese/example/README.md
  7:1  ✓ error  Found kangxi radical: ⾧  japanese/no-kangxi-radicals

✖ 1 problem (1 error, 0 warnings)
✓ 1 fixable problem.
Try to run: $ textlint --fix [file]

error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.

```

example/README.md をもとに戻したときに、`yarn test` が成功すること。

```bash
$ yarn test
yarn run v1.22.10
$ textlint README.md
Done in 1.00s.

```

康煕部首
> ⾧
