### PR TITLE
Fix broken CI badge: Travis CI to GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# textlint-rule-preset-japanese [![Build Status](https://travis-ci.org/textlint-ja/textlint-rule-preset-japanese.svg?branch=master)](https://travis-ci.org/textlint-ja/textlint-rule-preset-japanese)
+# textlint-rule-preset-japanese [![Actions Status: test](https://github.com/textlint-ja/textlint-rule-preset-japanese/actions/workflows/test.yml/badge.svg)](https://github.com/textlint-ja/textlint-rule-preset-japanese/actions/workflows/test.yml)
 
 [textlint rule preset](https://github.com/textlint/textlint/blob/master/docs/rule-preset.md "preset") for Japanese.
 


### PR DESCRIPTION
## 概要

TravisCIのバッジが参照されているのを見つけたので、GitHub Actionsのものを使うように変更する。

## 詳細

### 変更前

変更前は、下図のような状態だった。

![image](https://github.com/textlint-ja/textlint-rule-preset-japanese/assets/111689/080d52ec-0f41-4125-87cd-bb8be7624bc3)

### 変更後

変更後は、下図のような状態になる。

![image](https://github.com/textlint-ja/textlint-rule-preset-japanese/assets/111689/eee937e6-01ec-4132-a777-1214d89afbf4)

### 歴史

元々、以下のcommitでCIがTravis CIからGitHub Actionsに変更された。

- https://github.com/textlint-ja/textlint-rule-preset-japanese/commit/a7e30acb7b2f9b846e09677233bde0bd8633182c

### その他

https://github.com/textlint-ja 配下のリポジトリを見ると、バッジ画像のalt属性には概ね `Actions Status: test` という文字列が設定されている場合が多いため、今回はこれを踏襲することにした。異なるケースとして、https://github.com/textlint-ja/textlint-rule-preset-ja-technical-writing では `Actions Status` が設定されている。

バッジに割り当てられるa要素のhref属性について、既存のリポジトリを見ると、`workflow:test` というクエリでの検索結果を表すURLが割り当てられている。一方、GitHub ActionsのバッジURL生成機能では、個々のworkflowを一意に表すURLが用いられる。この2つは表示内容に異なる部分があり、例えば後者のURLではサイドバーのUIで現在test workflowのページを閲覧していることが分かる。今回このPull Requestでは、後者を採用することにした。