### PR TITLE
CI: add NODE_AUTH_TOKEN

### DIFF
--- a/.changeset/orange-jars-march.md
+++ b/.changeset/orange-jars-march.md
@@ -1,0 +1,5 @@
+---
+"textlint-rule-preset-japanese": patch
+---
+
+CI: add NODE_AUTH_TOKEN

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SHARED_BOT_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.SHARED_BOT_NPM_TOKEN }}
       - name: Publish next snapshot
         if: steps.changesets.outputs.published != 'true'
         run: |


### PR DESCRIPTION
setup-nodeによって生成された.npmrcはNODE_AUTH_TOKEN を参照するので、envに渡す必要がある